### PR TITLE
Add option -o | --loop + other improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ link:
 
 force_link:
 	@echo "Symlinking `pwd`/bin/cry to /usr/local/bin/cry"
-	@ln -sf `pwd`/bin/cry /usr/local/bin/cry
+	@sudo ln -sf `pwd`/bin/cry /usr/local/bin/cry

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ install: build force_link
 
 build: $(OUT_DIR)/cry
 
-$(OUT_DIR)/cry: src/cry.cr
+$(OUT_DIR)/cry: src/** lib
 	@echo "Building cry in $(shell pwd)"
 	@mkdir -p $(OUT_DIR)
-	@shards
 	@crystal build -o $(OUT_DIR)/cry src/cry.cr -p --no-debug
+
+lib:
+	@shards
 
 run:
 	$(OUT_DIR)/cry

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ link:
 	@ln -s `pwd`/bin/cry /usr/local/bin/cry
 
 force_link:
-	@echo "Symlinking `pwd`/bin/cry to /usr/local/bin/amber"
+	@echo "Symlinking `pwd`/bin/cry to /usr/local/bin/cry"
 	@ln -sf `pwd`/bin/cry /usr/local/bin/cry

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ brew install elorest/crystal/cry
    - `cry scripts/stuff.cr`
 1. *back*: open and previous run in editor mode.
    - `cry -b 1` ... copies previous run to tmp file for editing and runs when editor is closed.
+1. *loop*: continuously edit and execute code.
+   - `cry -o -b 1` ... copies previous run to tmp file for editing and runs when editor is closed in a loop.
 1. *log*: show a log of all previous runs.
    - `cry --log`
 
@@ -48,6 +50,7 @@ Options:
   -e, --editor  Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified
                 (default: vim)
   -l, --log     Prints results of previous run
+  -o, --loop    Runs editor in a loop (can be combined with e.g. -b 1)
 ```
 
 ## Contributing

--- a/shard.lock
+++ b/shard.lock
@@ -5,8 +5,8 @@ shards:
     version: 0.6.3
 
   cli:
-    github: mosop/cli
-    version: 0.6.10
+    github: amberframework/cli
+    version: 0.7.0
 
   optarg:
     github: mosop/optarg

--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,8 @@ targets:
 
 dependencies:
   cli:
-    github: mosop/cli
-    version: ~> 0.6.10
+    github: amberframework/cli
+    version: ~> 0.7.0
 
 crystal: 0.23.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cry
-version: 0.1.1
+version: 0.2.0
 
 authors:
   - Isaac Sloan <isaac@isaacsloan.com>

--- a/src/cry/version.cr
+++ b/src/cry/version.cr
@@ -1,3 +1,3 @@
 module Cry
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Add option -o | --loop
Adds option -o | --loop to continuously run editor and execute.
Option can be combined with option -b 1 to keep working on the
same content and executing it.

 Build improvements
- bump version to 0.3.0
- require Crystal 0.24.1
- do not make assumption about user's way to obtain increased privileges

Makefile improvements
- Binary depends on all source files, not just src/cry.cr
- Rebuild doesn't trigger shards install if lib/ exists