### PR TITLE
Add option -o | --loop, add some build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ install: build force_link
 
 build: $(OUT_DIR)/cry
 
-$(OUT_DIR)/cry: src/cry.cr
+$(OUT_DIR)/cry: src/** lib
 	@echo "Building cry in $(shell pwd)"
 	@mkdir -p $(OUT_DIR)
-	@shards
 	@crystal build -o $(OUT_DIR)/cry src/cry.cr -p --no-debug
+
+lib:
+	@shards
 
 run:
 	$(OUT_DIR)/cry
@@ -23,4 +25,4 @@ link:
 
 force_link:
 	@echo "Symlinking `pwd`/bin/cry to /usr/local/bin/cry"
-	@sudo ln -sf `pwd`/bin/cry /usr/local/bin/cry
+	@ln -sf `pwd`/bin/cry /usr/local/bin/cry

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ brew install elorest/crystal/cry
    - `cry scripts/stuff.cr`
 1. *back*: open and previous run in editor mode.
    - `cry -b 1` ... copies previous run to tmp file for editing and runs when editor is closed.
+1. *loop*: continuously edit and execute code.
+   - `cry -o -b 1` ... copies previous run to tmp file for editing and runs when editor is closed in a loop.
 1. *log*: show a log of all previous runs.
    - `cry --log`
 
@@ -48,6 +50,7 @@ Options:
   -e, --editor  Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified
                 (default: vim)
   -l, --log     Prints results of previous run
+  -o, --loop    Runs editor in a loop (can be combined with e.g. -b 1)
 ```
 
 ## Contributing

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cry
-version: 0.2.0
+version: 0.3.0
 
 authors:
   - Isaac Sloan <isaac@isaacsloan.com>

--- a/src/cry/command.cr
+++ b/src/cry/command.cr
@@ -3,17 +3,16 @@ require "colorize"
 
 module Cry
   class Command < ::Cli::Command
-    @filename : String
-    @result_filename : String
-    @filename = new_file
-    @result_filename = new_result_file
+
+    @filename_seed : Int64
+    @filename_seed = Time.now.epoch_ms
 
     class Options
       arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
       bool ["-l", "--log"], desc: "Prints results of previous runs"
       string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: ENV["EDITOR"]? || "vim"
       string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
-      bool ["-o", "--loop"], desc: "Runs editor in a loop (can be combined with e.g. -b 1)"
+      bool ["-r", "--repeat"], desc: "Runs editor in a loop"
     end
 
     class Help
@@ -21,26 +20,25 @@ module Cry
     end
 
     def prepare_file
-      back_i = options.back.to_i(strict: false)
       _filename = if File.exists?(args.code)
                     args.code
-                  elsif back_i == 0
-                    @filename = new_file
-                  elsif back_i > 0
-                    Dir.glob("./tmp/*_console.cr").sort.reverse[back_i - 1]?
+                  elsif @back.not_nil! > 0
+                    Dir.glob("./tmp/*_console.cr").sort.reverse[@back.not_nil! - 1]?
                   end
 
-      system("cp #{_filename} #{@filename}") if _filename && File.exists?(_filename)
+      system("cp #{_filename} #{filename}") if _filename && File.exists?(_filename)
     end
 
-    def new_file
-      "./tmp/#{Time.now.epoch_ms}_console.cr"
+    def filename
+      "./tmp/#{@filename_seed}_console.cr"
     end
-    def new_result_file
-      @filename.sub("console.cr", "console_result.log")
+    def result_filename
+      "./tmp/#{@filename_seed}_console_result.log"
     end
 
     def run
+      @back = if args.repeat?; 1 else args.back.to_i(strict: false) || 0 end
+
       if args.log?
         logs = Dir.glob("./tmp/*_console_result.log")
         str = String.build do |s|
@@ -59,26 +57,26 @@ module Cry
 
         loop do
           unless args.code.blank? || File.exists?(args.code)
-            File.write(@filename, "puts (#{args.code}).inspect")
+            File.write(filename, "puts (#{args.code}).inspect")
           else
             prepare_file
-            system("#{options.editor} #{@filename}")
+            system("#{options.editor} #{filename}")
           end
 
-          break unless File.exists?(@filename)
+          break unless File.exists?(filename)
 
           result = ""
-          result = `crystal eval 'require "#{@filename}";'`
+          result = `crystal eval 'require "#{filename}";'`
 
-          File.write(@result_filename, result) unless result.nil?
+          File.write(result_filename, result) unless result.nil?
           puts result
 
-          break unless args.loop?
+          break unless args.repeat?
           puts "\nENTER to edit, q to quit"
           input = gets
           break if input=~ /^q/i
-          @filename = new_file
-          @result_filename = new_result_file
+
+          @filename_seed = Time.now.epoch_ms
         end
       end
     end

--- a/src/cry/version.cr
+++ b/src/cry/version.cr
@@ -1,3 +1,3 @@
 module Cry
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/src/cry/version.cr
+++ b/src/cry/version.cr
@@ -1,3 +1,3 @@
 module Cry
-  VERSION = "0.3.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- add option -o | --loop
- update README.md
- bump version to 0.3.0
- require Crystal 0.24.1
- binary depends on all source files, not just src/cry.cr
- do not make assumption about user's way to obtain increased privileges
- rebuild doesn't trigger shards install if lib/ exists

Option -o | --loop will continuously run editor and execute.
It can be combined with option -b 1 to keep working on the same content
and executing it.