### PR TITLE
Uses mosop repo instead of fork

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ targets:
 
 dependencies:
   cli:
-    github: amberframework/cli
+    github: mosop/cli
     version: ~> 0.7.0
 
 crystal: 0.24.1


### PR DESCRIPTION
`amberframework/cli` repo no longer exists. This should be pointing to `mosop/cli` since it is more up to date and contains all fork changes.